### PR TITLE
skip embedding file creation on empty lines

### DIFF
--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -200,7 +200,6 @@ var initFlags = []cli.Flag{
 	&cli.StringFlag{
 		Name:    embedOutputTypesFlag,
 		Aliases: []string{"eot"},
-		Value:   "yaml",
 		Usage:   "List of output formats to embed (swagger.json, swagger.yaml), comma-separated (e.g. json,yaml)",
 	},
 }

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -349,6 +349,11 @@ func (g *Gen) embedOutputTypes(config *Config, outputTypes []string) error {
 		embeddingLines = append(embeddingLines, fmt.Sprintf(embedFmt, outputFileName, embedName))
 	}
 
+	if len(embeddingLines) == 0 {
+		g.debug.Printf("Skip creating embedded swagger.go files: nothing to embed")
+		return nil
+	}
+
 	embeddingFileContent := fmt.Sprintf(embeddingFileContentFmt, strings.Join(embeddingLines, "\n"))
 
 	var filename = "swagger.go"


### PR DESCRIPTION
**Describe the PR**
Fix swagger.go file creation when there are no files to be embedded.
Remove default value from -eot/-embedOutputTypes flag